### PR TITLE
Add quotes around variables to prevent splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # IDPSSO X509 fingerprint
 Compute x509 fingerprint from IDPSSO xml file.
 
+## Requirements
+
+* Perl
+* `openssl`
+* `cut`
+
 ## Manual
 
-1. Download an IDPSSO configuration file from your keycloak instance in the installation tab. 
-2. execute:
-```./x509_fingerprint.sh path_to_your_IDPSSO_file.xml```
+1. Download an IDPSSODescriptor or SPSSODescriptor configuration file from your keycloak instance (see "Installation" tab of a client).
+2. Execute the script: `./x509_fingerprint.sh path_to_your_IDPSSO_file.xml`
 3. Et Voilà !

--- a/x509_fingerprint.sh
+++ b/x509_fingerprint.sh
@@ -1,5 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
-BASE_DIR="$(dirname "$0")"
-$BASE_DIR/x509_pem_extractor.pl $@ | openssl x509 -noout -fingerprint -sha1
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+"$BASE_DIR/x509_pem_extractor.pl" "$@" | \
+    openssl x509 -noout -fingerprint -sha1 | \
+    cut -d'=' -f2

--- a/x509_pem_extractor.pl
+++ b/x509_pem_extractor.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use strict;
 use warnings;
@@ -28,7 +28,7 @@ my $end = "-----END CERTIFICATE-----";
 my $count = floor((length $result)/64);
 for (my $i = 0; $i <= $count; $i++) {
     my $str = substr $result, ($i*64), 64;
-    $start = $start . "\n" . $str 
+    $start = $start . "\n" . $str
 }
 
 $start = $start . "\n" . $end . "\n";


### PR DESCRIPTION
This adds quotes around the bash variables to prevent splitting.
Also added requirements to README file (+ cut for just printing the fingerprint).